### PR TITLE
Refactor branch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,96 +39,99 @@ Here are the steps to run the application locally, including both front-end and 
 
 ### 1. Clone the Repository
 
-```
+```bash
 git clone https://github.com/asagisi/COMP-4002_Team-SAD_Group-Project
 cd ./COMP-4002_Team-SAD_Group-Project
 ```
 
 ### 2. Install Dependencies
 
-#### Front-End
-```
-cd ./apps/frontend
+From the repo root:
+
+```bash
 npm install
 ```
 
-#### Back-End
-```
-cd ./apps/backend
-npm install
-```
+This project uses npm workspaces, so installing from the root will install dependencies for both `apps/frontend` and `apps/backend`.
 
 ### 3. Configure Environment Variables
 
-Create a `.env` file in both front-end and back-end directories.
+Create a `.env` file in both the front-end and back-end directories.
 
-Front-End `.env`
+Front-End `apps/frontend/.env`
 
 ```env
-NEXT_PUBLIC_CLERK_FRONTEND_API=<your-clerk-frontend-api>
-NEXT_PUBLIC_API_URL=http://localhost:5000
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_clerk_publishable_key
+VITE_API_URL=http://localhost:3000
 ```
 
-Back-End `.env`
+Back-End `apps/backend/.env`
 
 ```env
-CLERK_API_KEY=<your-clerk-api-key>
-DATABASE_URL=postgres://username:password@localhost:5432/<dbname>
-PORT=5000
+CLERK_SECRET_KEY=sk_test_your_clerk_secret_key
+DATABASE_URL=postgresql://username:password@your-neon-host/neondb?sslmode=require
+PORT=3000
 ```
 
 Replace placeholders with your actual values. Do not commit secrets to GitHub.
 
 ### 4. Set Up the Database
 
-If using PostgreSQL:
+Run the existing migrations:
 
-```env
-psql -U <username> -c "CREATE DATABASE <dbname>;"
+```bash
+npx prisma migrate deploy --schema apps/backend/prisma/schema.prisma
 ```
 
-Run migrations to set up your schema:
+If you want local seed data:
 
-```Bash
-cd backend
-npx prisma migrate dev
-# or your migration tool
+```bash
+npm run seed --workspace=@team-sad/backend
 ```
 
 ### 5. Start the Applications
 
-#### Back-End
-```Bash
-cd backend
+To run both applications together from the repo root:
+
+```bash
 npm run dev
 ```
 
-API will run at http://localhost:5000
+This starts:
 
-#### Front-End
+- the back-end on `http://localhost:3000`
+- the front-end on Vite's local dev server
 
-```Bash
-cd frontend
-npm run dev
+If you want to run them separately:
+
+Back-End
+
+```bash
+npm run start:backend
 ```
 
-Front-end will run at http://localhost:3000
+Front-End
+
+```bash
+npm run start:frontend
+```
 
 ### 6. Test Authentication
 
-  1. Go to the front-end login page.
-  2. Register a new account using email login.
-  3. Verify that user-specific data is available through the API.
+1. Go to the front-end in your browser.
+2. Use the Clerk login button in the header to sign up or sign in.
+3. Verify that guest users can browse without personalized changes.
+4. Verify that signed-in users can save show-specific changes like hide, favourites, ratings, and watch progress.
 
 ### 7. Additional Notes
 
-  - Ensure that the front-end `.env` points to your local back-end URL.
-  - Clerk authentication requires correct API keys and project environment configuration.
-  - To reset the database (development only):
+- Ensure that the front-end `.env` points to your local back-end URL.
+- If backend auth changes are not reflected, restart the back-end after updating `.env`.
+- If Prisma types are out of date after a schema change, run:
 
-  ```Bash
-  npx prisma migrate reset
-  ```
+```bash
+npm run build --workspace=@team-sad/backend
+```
 
 # React + TypeScript + Vite
 

--- a/apps/backend/prisma/migrations/20260423190000_add_current_favourite_to_user/migration.sql
+++ b/apps/backend/prisma/migrations/20260423190000_add_current_favourite_to_user/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "User"
+ADD COLUMN "currentFavouriteId" INTEGER;
+
+ALTER TABLE "User"
+ADD CONSTRAINT "User_currentFavouriteId_fkey"
+FOREIGN KEY ("currentFavouriteId") REFERENCES "Show"("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;
+
+CREATE INDEX "User_currentFavouriteId_idx" ON "User"("currentFavouriteId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -14,9 +14,11 @@ enum WatchStatus {
 }
 
 model User {
-  id          Int        @id @default(autoincrement())
-  clerkUserId String     @unique
-  userShow    UserShow[]
+  id                 Int    @id @default(autoincrement())
+  clerkUserId        String @unique
+  currentFavourite   Show?  @relation("CurrentFavouriteShow", fields: [currentFavouriteId], references: [id], onDelete: SetNull)
+  currentFavouriteId Int?
+  userShow           UserShow[]
 }
 
 model Show {
@@ -26,7 +28,8 @@ model Show {
   year     Int
   episodes Int
 
-  userShow UserShow[]
+  currentFavouriteFor User[]   @relation("CurrentFavouriteShow")
+  userShow            UserShow[]
 }
 
 model UserShow {

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -15,9 +15,6 @@ app.use(clerkMiddleware());
 // Middleware to parse JSON request bodies
 app.use(express.json());
 
-// Clerk auth
-app.use(clerkMiddleware());
-
 // Interface for health check response
 interface HealthCheckResponse {
     status: string;

--- a/apps/backend/src/controllers/showController.ts
+++ b/apps/backend/src/controllers/showController.ts
@@ -1,6 +1,14 @@
 import { Request, Response } from "express";
 import { WatchStatus } from "@prisma/client";
-import { clearWatchProgress, getShowsForUser, updateShowHidden, updateShowPreferences, updateWatchProgress } from "../services/showService";
+import {
+  clearWatchProgress,
+  getCurrentFavouriteShowForUser,
+  getShowsForUser,
+  updateCurrentFavouriteShow,
+  updateShowHidden,
+  updateShowPreferences,
+  updateWatchProgress,
+} from "../services/showService";
 
 export async function getShows(req: Request, res: Response): Promise<void> {
   const userId: number | undefined = res.locals.userId;
@@ -11,6 +19,32 @@ export async function getShows(req: Request, res: Response): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to fetch shows";
     res.status(500).json({ error: message });
+  }
+}
+
+export async function getCurrentFavouriteShow(req: Request, res: Response): Promise<void> {
+  const userId: number | undefined = res.locals.userId;
+
+  try {
+    const data = await getCurrentFavouriteShowForUser(userId);
+    res.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch current favourite show";
+    res.status(500).json({ error: message });
+  }
+}
+
+export async function patchCurrentFavouriteShow(req: Request, res: Response): Promise<void> {
+  const userId: number = res.locals.userId;
+  const showId = Number(req.params.showId);
+
+  try {
+    const data = await updateCurrentFavouriteShow(userId, showId);
+    res.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to update current favourite show";
+    const status = message === "Show not found" ? 404 : 500;
+    res.status(status).json({ error: message });
   }
 }
 

--- a/apps/backend/src/routes/showRoutes.ts
+++ b/apps/backend/src/routes/showRoutes.ts
@@ -1,6 +1,14 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { getAuth } from "@clerk/express";
-import { deleteShowProgress, getShows, patchShowHidden, patchShowPreferences, patchShowProgress } from "../controllers/showController";
+import {
+  deleteShowProgress,
+  getCurrentFavouriteShow,
+  getShows,
+  patchCurrentFavouriteShow,
+  patchShowHidden,
+  patchShowPreferences,
+  patchShowProgress,
+} from "../controllers/showController";
 import { findOrCreateUser } from "../middleware/findOrCreateUser";
 import { validateHiddenPayload, validatePreferencesPayload, validateProgressPayload, validateShowIdParam } from "../middleware/showValidation";
 
@@ -16,6 +24,8 @@ function requireSignedIn(req: Request, res: Response, next: NextFunction): void 
 }
 
 router.get("/", findOrCreateUser, getShows);
+router.get("/current-favourite", findOrCreateUser, getCurrentFavouriteShow);
+router.patch("/current-favourite/:showId", requireSignedIn, findOrCreateUser, validateShowIdParam, patchCurrentFavouriteShow);
 
 router.patch("/:showId/hidden", requireSignedIn, findOrCreateUser, validateShowIdParam, validateHiddenPayload, patchShowHidden);
 router.patch("/:showId/preferences", requireSignedIn, findOrCreateUser, validateShowIdParam, validatePreferencesPayload, patchShowPreferences);

--- a/apps/backend/src/services/showService.ts
+++ b/apps/backend/src/services/showService.ts
@@ -14,6 +14,13 @@ type ShowListItem = {
   status: WatchStatus;
 };
 
+type ShowSummary = {
+  id: number;
+  title: string;
+  genre: string;
+  year: number;
+};
+
 export async function getShowsForUser(userId?: number): Promise<ShowListItem[]> {
   const rows = await prisma.show.findMany({
     include: {
@@ -51,6 +58,49 @@ export async function getShowsForUser(userId?: number): Promise<ShowListItem[]> 
       status: rel?.status ?? WatchStatus.NOT_STARTED,
     };
   });
+}
+
+export async function getCurrentFavouriteShowForUser(userId?: number): Promise<ShowSummary | null> {
+  if (!userId) {
+    return null;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      currentFavourite: {
+        select: {
+          id: true,
+          title: true,
+          genre: true,
+          year: true,
+        },
+      },
+    },
+  });
+
+  return user?.currentFavourite ?? null;
+}
+
+export async function updateCurrentFavouriteShow(userId: number, showId: number): Promise<ShowSummary> {
+  const show = await prisma.show.findUnique({ where: { id: showId } });
+  if (!show) {
+    throw new Error("Show not found");
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      currentFavouriteId: showId,
+    },
+  });
+
+  return {
+    id: show.id,
+    title: show.title,
+    genre: show.genre,
+    year: show.year,
+  };
 }
 
 export async function updateShowHidden(userId: number, showId: number, isHidden: boolean): Promise<ShowListItem> {

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import './App.css'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { AuthBridge } from './auth/AuthBridge'
 import { Header } from './layout/header/header'
 import { Home } from './layout/pages/Home'
 import { ShowListPage } from './layout/pages/ShowListPage'
@@ -15,6 +16,7 @@ import { Footer } from './layout/footer/footer'
 function App() {
   return (
     <Router>
+      <AuthBridge />
       <div className="App">
         <Header />
         <main className="main-content">

--- a/apps/frontend/src/auth/AuthBridge.tsx
+++ b/apps/frontend/src/auth/AuthBridge.tsx
@@ -1,0 +1,24 @@
+import { useAuth } from "@clerk/react";
+import { useEffect } from "react";
+import {
+  resetShowRepositoryCache,
+  setShowRepositoryAuthTokenProvider,
+} from "../repositories/showRepository";
+
+export const AuthBridge = () => {
+  const { getToken, userId } = useAuth();
+
+  useEffect(() => {
+    setShowRepositoryAuthTokenProvider(() => getToken());
+
+    return () => {
+      setShowRepositoryAuthTokenProvider(null);
+    };
+  }, [getToken]);
+
+  useEffect(() => {
+    resetShowRepositoryCache();
+  }, [userId]);
+
+  return null;
+};

--- a/apps/frontend/src/components/favouriteshow/FavouriteShow.css
+++ b/apps/frontend/src/components/favouriteshow/FavouriteShow.css
@@ -30,7 +30,6 @@
 	outline: none;
 }
 
-
 .favourite-dropdown {
 	position: absolute;
 	top: 100%;
@@ -59,4 +58,9 @@
 .favourite-option:hover {
 	background: rgba(224, 224, 224, 0.08);
 	cursor: pointer;
+}
+
+.favourite-error {
+	font-size: 0.82rem;
+	color: #ffd1d1;
 }

--- a/apps/frontend/src/components/favouriteshow/FavouriteShow.tsx
+++ b/apps/frontend/src/components/favouriteshow/FavouriteShow.tsx
@@ -3,34 +3,39 @@ import { showRepository } from '../../repositories/showRepository';
 import './FavouriteShow.css';
 import { useFavouriteShow } from '../../hooks/useFavouriteShow';
 
-// this is the favourite show component
-
 export const FavouriteShowSelector: React.FC = () => {
-    const { currentFavourite, setCurrentFavourite } = useFavouriteShow();
+    const { currentFavourite, setCurrentFavourite, loading, error, isSignedIn } = useFavouriteShow();
     const [query, setQuery] = useState('');
 
 
     // this const filters the shows based on the query and limits to top 3 results; don't want to overflow the page
     const filteredShows = showRepository
         .getAllShows()
-        .filter(show => show.title.toLowerCase().includes(query.toLowerCase()))
+        .filter(show => show.title.toLowerCase().startsWith(query.toLowerCase())) // starts with just feels better than an inlcudes type of query
         .slice(0, 3); // remember, slice returns a piece of the array using its index ; meanwhile splice would change the original array
 
     return (
         <div className="favourite-show">
             <div className="favourite-label">Current favourite show:</div>
             <div className="favourite-current">
-                {currentFavourite ? currentFavourite.title : 'Go ahead, pick one!'}
+                {loading
+                    ? 'Loading your favourite...'
+                    : currentFavourite
+                        ? currentFavourite.title
+                        : isSignedIn
+                            ? 'Go ahead, pick one!'
+                            : error}
             </div>
 
             <input
                 className="favourite-input"
                 type="text"
                 value={query}
+                disabled={!isSignedIn}
                 onChange={event => setQuery(event.target.value)}
-                placeholder="Search shows..."
+                placeholder={isSignedIn ? "Search shows..." : "Sign in to pick a favourite"}
             />
-            {query.trim().length > 0 && (
+            {isSignedIn && query.trim().length > 0 && (
                 <div className="favourite-dropdown">
                     {filteredShows.length === 0 ? ( // if length of filtered shows is 0, it will show no matches
                         <div className="favourite-empty">No matches!
@@ -41,8 +46,8 @@ export const FavouriteShowSelector: React.FC = () => {
                                 key={show.id}
                                 type="button"
                                 className="favourite-option"
-                                onClick={() => {
-                                    setCurrentFavourite(show); // this updates the state of the favourite show.
+                                onClick={async () => {
+                                    await setCurrentFavourite(show); // this updates the state of the favourite show.
                                     setQuery(''); // to close dropdown after selection
                                 }}>
                                 {show.title}
@@ -51,6 +56,9 @@ export const FavouriteShowSelector: React.FC = () => {
                         ))
                     )}
                 </div>
+            )}
+            {isSignedIn && error && (
+                <div className="favourite-error" role="alert">{error}</div>
             )}
         </div>
     );

--- a/apps/frontend/src/hooks/useFavouriteShow.ts
+++ b/apps/frontend/src/hooks/useFavouriteShow.ts
@@ -1,13 +1,87 @@
-import { useState } from 'react';
+import { useAuth } from '@clerk/react';
+import { useEffect, useState } from 'react';
 import type { Show } from '../../../../shared/types/Show';
+import { AUTH_REQUIRED_MESSAGE, showRepository } from '../repositories/showRepository';
 
 // custom hook for favourite show state.
 // components can use this instead of passing favourite state through props.
 export const useFavouriteShow = () => {
-    const [currentFavourite, setCurrentFavourite] = useState<Show | null>(null);
+    const { isSignedIn, userId } = useAuth();
+    const [currentFavourite, setCurrentFavouriteState] = useState<Show | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadCurrentFavourite = async () => {
+            if (!isSignedIn) {
+                if (isMounted) {
+                    setCurrentFavouriteState(null);
+                    setLoading(false);
+                    setError(AUTH_REQUIRED_MESSAGE);
+                }
+                return;
+            }
+
+            setLoading(true);
+            setError('');
+
+            try {
+                const favourite = await showRepository.getCurrentFavouriteShow();
+
+                if (isMounted) {
+                    setCurrentFavouriteState(favourite);
+                    setError('');
+                }
+            } catch (loadError) {
+                const message =
+                    loadError instanceof Error ? loadError.message : 'Failed to load current favourite show.';
+
+                if (isMounted) {
+                    setCurrentFavouriteState(null);
+                    setError(message);
+                }
+            } finally {
+                if (isMounted) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        void loadCurrentFavourite();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [isSignedIn, userId]);
+
+    const setCurrentFavourite = async (show: Show) => {
+        if (!isSignedIn) {
+            setError(AUTH_REQUIRED_MESSAGE);
+            return;
+        }
+
+        const previous = currentFavourite;
+        setCurrentFavouriteState(show);
+        setError('');
+
+        try {
+            const persisted = await showRepository.setCurrentFavouriteShow(show.id);
+            setCurrentFavouriteState(persisted);
+        } catch (saveError) {
+            setCurrentFavouriteState(previous);
+            const message =
+                saveError instanceof Error ? saveError.message : 'Failed to save current favourite show.';
+            setError(message);
+        }
+    };
 
     return {
         currentFavourite,
         setCurrentFavourite,
+        loading,
+        error,
+        isSignedIn,
     };
 };

--- a/apps/frontend/src/hooks/useShowLists.ts
+++ b/apps/frontend/src/hooks/useShowLists.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useAuth } from '@clerk/react';
 import { showRepository } from '../repositories/showRepository';
 import type { Show } from '../../../../shared/types/Show';
 
@@ -12,6 +13,7 @@ type ShowWithPrefs = Show & {
 // now component doesnt perform logic and such, renders a ui.
 
 export const useShowLists = () => {
+    const { userId } = useAuth();
     const [shows, setShows] = useState<ShowWithPrefs[]>(showRepository.getCachedShows());
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
@@ -35,7 +37,7 @@ export const useShowLists = () => {
         };
 
         loadShows();
-    }, []);
+    }, [userId]);
 
     // this const will filter shows based on search, hidden status.
     const filteredShow = shows.filter(show =>

--- a/apps/frontend/src/repositories/showRepository.ts
+++ b/apps/frontend/src/repositories/showRepository.ts
@@ -81,7 +81,7 @@ function upsertCachedShow(updated: ShowWithPrefs): void {
     saveShowCache(next);
 }
 
-const STATUS_MESSAGES: Record<number, string> = {
+export const STATUS_MESSAGES: Record<number, string> = {
     400: "That request doesn't look right. Please try again.",
     401: "Please sign in to make changes.",
     403: "You don't have permission to do that.",
@@ -165,6 +165,24 @@ export const showRepository = {
         return data;
     },
 
+    getCurrentFavouriteShow: async (): Promise<Show | null> => {
+        const response = await safeFetch(`${API_BASE}/current-favourite`, {
+            cache: "no-store",
+            headers: await buildAuthHeaders(),
+        });
+
+        return parseResponse<Show | null>(response);
+    },
+
+    setCurrentFavouriteShow: async (showId: number): Promise<Show> => {
+        const response = await safeFetch(`${API_BASE}/current-favourite/${showId}`, {
+            method: "PATCH",
+            headers: await buildJsonHeaders(),
+        });
+
+        return parseResponse<Show>(response);
+    },
+
     /**
      * Update hidden state for a show
      */
@@ -227,3 +245,5 @@ export const showRepository = {
         return data;
     },
 };
+
+export const AUTH_REQUIRED_MESSAGE = STATUS_MESSAGES[401];

--- a/apps/frontend/src/repositories/showRepository.ts
+++ b/apps/frontend/src/repositories/showRepository.ts
@@ -2,6 +2,7 @@ import type { Show } from "../../../../shared/types/Show";
 import { shows } from "../../../backend/data/shows";
 
 export type ApiWatchStatus = "NOT_STARTED" | "WATCHING" | "FINISHED";
+type AuthTokenProvider = () => Promise<string | null>;
 
 export type ShowWithPrefs = Show & {
     isHidden: boolean;
@@ -12,11 +13,27 @@ export type ShowWithPrefs = Show & {
     status: ApiWatchStatus;
 };
 
-const DEFAULT_USER_ID = 1;
 const API_BASE = `${import.meta.env.VITE_API_URL || ""}/api/v1/shows`;
 const SHOW_CACHE_KEY = "team-sad-shows-cache-v1";
 
 let showCache: ShowWithPrefs[] | null = null;
+let authTokenProvider: AuthTokenProvider | null = null;
+
+export function setShowRepositoryAuthTokenProvider(
+    provider: AuthTokenProvider | null
+): void {
+    authTokenProvider = provider;
+}
+
+export function resetShowRepositoryCache(): void {
+    showCache = null;
+
+    if (typeof window === "undefined") {
+        return;
+    }
+
+    window.localStorage.removeItem(SHOW_CACHE_KEY);
+}
 
 function loadShowCache(): ShowWithPrefs[] | null {
     if (showCache) {
@@ -80,6 +97,25 @@ function statusToFriendlyMessage(status: number): string {
     return "Something went wrong. Please try again.";
 }
 
+async function buildAuthHeaders(): Promise<Record<string, string>> {
+    const token = authTokenProvider ? await authTokenProvider() : null;
+
+    if (!token) {
+        return {};
+    }
+
+    return {
+        Authorization: `Bearer ${token}`,
+    };
+}
+
+async function buildJsonHeaders(): Promise<Record<string, string>> {
+    return {
+        "Content-Type": "application/json",
+        ...(await buildAuthHeaders()),
+    };
+}
+
 async function parseResponse<T>(response: Response): Promise<T> {
     if (response.ok) return response.json() as Promise<T>;
 
@@ -91,7 +127,10 @@ async function parseResponse<T>(response: Response): Promise<T> {
 
 async function safeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     try {
-        return await fetch(input, init);
+        return await fetch(input, {
+            credentials: "include",
+            ...init,
+        });
     } catch {
         throw new Error("Can't reach the server right now. Check your connection and try again.");
     }
@@ -117,8 +156,9 @@ export const showRepository = {
      * Retrieve all shows with user relationship data from backend
      */
     getAllShowsFromApi: async (): Promise<ShowWithPrefs[]> => {
-        const response = await safeFetch(`${API_BASE}?userId=${DEFAULT_USER_ID}`, {
+        const response = await safeFetch(API_BASE, {
             cache: "no-store",
+            headers: await buildAuthHeaders(),
         });
         const data = await parseResponse<ShowWithPrefs[]>(response);
         saveShowCache(data);
@@ -131,11 +171,8 @@ export const showRepository = {
     setHidden: async (showId: number, isHidden: boolean): Promise<ShowWithPrefs> => {
         const response = await safeFetch(`${API_BASE}/${showId}/hidden`, {
             method: "PATCH",
-            headers: {
-                "Content-Type": "application/json",
-            },
+            headers: await buildJsonHeaders(),
             body: JSON.stringify({
-                userId: DEFAULT_USER_ID,
                 isHidden,
             }),
         });
@@ -151,11 +188,8 @@ export const showRepository = {
     ): Promise<ShowWithPrefs> => {
         const response = await safeFetch(`${API_BASE}/${showId}/preferences`, {
             method: "PATCH",
-            headers: {
-                "Content-Type": "application/json",
-            },
+            headers: await buildJsonHeaders(),
             body: JSON.stringify({
-                userId: DEFAULT_USER_ID,
                 ...payload,
             }),
         });
@@ -171,11 +205,8 @@ export const showRepository = {
     ): Promise<ShowWithPrefs> => {
         const response = await safeFetch(`${API_BASE}/${showId}/progress`, {
             method: "PATCH",
-            headers: {
-                "Content-Type": "application/json",
-            },
+            headers: await buildJsonHeaders(),
             body: JSON.stringify({
-                userId: DEFAULT_USER_ID,
                 ...payload,
             }),
         });
@@ -188,12 +219,7 @@ export const showRepository = {
     clearWatchProgress: async (showId: number): Promise<ShowWithPrefs> => {
         const response = await safeFetch(`${API_BASE}/${showId}/progress`, {
             method: "DELETE",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-                userId: DEFAULT_USER_ID,
-            }),
+            headers: await buildJsonHeaders(),
         });
 
         const data = await parseResponse<ShowWithPrefs>(response);


### PR DESCRIPTION
this pr fixes the shared clerk auth flow stuff that was causing some issues. Old hardcoded user logic was still around so I removed it. auth bridge is added so signed in users can actually make changes. The local setup section in readme was adjusted as well to be a bit more accurate; things like env names, paths and ports. Also a big one was the favourite show in the header was neglected, so I added sign in functionality to that so it matters now. Sign in and sign out behaviour has been tested in here, so everything should be good now!